### PR TITLE
Fix leaderboard HTML injection

### DIFF
--- a/public/js/leaderboard.js
+++ b/public/js/leaderboard.js
@@ -43,14 +43,21 @@ async function loadLeaderboard() {
         
         const rankClass = index < 3 ? `rank-${index + 1}` : '';
         
-        tbody.append(`
-          <tr>
-            <td class="rank ${rankClass}">${index + 1}</td>
-            <td>${entry.username || 'Unknown'}</td>
-            <td>${entry.score || 0}</td>
-            <td>${formattedDate}</td>
-          </tr>
-        `);
+        const tr = $('<tr>');
+        $('<td>')
+          .addClass('rank ' + rankClass)
+          .text(index + 1)
+          .appendTo(tr);
+        $('<td>')
+          .text(entry.username || 'Unknown')
+          .appendTo(tr);
+        $('<td>')
+          .text(entry.score || 0)
+          .appendTo(tr);
+        $('<td>')
+          .text(formattedDate)
+          .appendTo(tr);
+        tbody.append(tr);
       });
     }
   } catch (error) {


### PR DESCRIPTION
## Summary
- prevent HTML injection in leaderboard by appending DOM nodes directly

## Testing
- `npm install` *(fails: TypeError: OAuth2Strategy requires a clientID option)*

------
https://chatgpt.com/codex/tasks/task_e_683fe37eb05c833190ae0d9aea7648a2