### PR TITLE
Fix bullet collision handling

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -146,6 +146,7 @@ class Bullet {
       ) {
         this.game.checkAnswer(index, { x: this.x, y: this.y });
         this.el.remove();
+        this.isDead = true;
         return false;
       }
     });


### PR DESCRIPTION
## Summary
- stop updating bullets after they collide with answers

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683fe79f40e88331aaaf0fd885eb3e39