### PR TITLE
Refactor shared auth helpers

### DIFF
--- a/game.html
+++ b/game.html
@@ -19,6 +19,7 @@
     </div>
   </div>
 
+  <script src="js/common.js"></script>
   <script src="js/game.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -84,92 +84,22 @@
     </div>
   </div>
 
+  <script src="js/common.js"></script>
   <script>
-    // Функции для работы с Discord авторизацией
-    async function checkAuthStatus() {
-      try {
-        const response = await fetch('/api/auth-status');
-        const data = await response.json();
-        
-        if (data.authenticated) {
-          // Пользователь авторизован
-          $('#not-logged').hide();
-          $('#logged-in').show();
-          $('#username').text(data.user.username);
-          
-          // Устанавливаем аватар пользователя
-          if (data.user.avatar) {
-            const avatarUrl = `https://cdn.discordapp.com/avatars/${data.user.id}/${data.user.avatar}.png`;
-            $('#user-avatar').attr('src', avatarUrl);
-          } else {
-            // Дефолтный аватар если у пользователя нет аватара
-            $('#user-avatar').attr('src', 'https://cdn.discordapp.com/embed/avatars/0.png');
-          }
-        } else {
-          // Пользователь не авторизован
-          $('#not-logged').show();
-          $('#logged-in').hide();
-        }
-      } catch (error) {
-        console.error('Ошибка при проверке статуса авторизации:', error);
-      }
-    }
-    
-    // Обработчики событий для кнопок авторизации
-    function setupAuthButtons() {
-      // Кнопка входа через Discord
-      $('#discord-login').on('click', function() {
-        window.location.href = '/auth/discord';
-      });
-      
-      // Кнопка выхода
-      $('#logout').on('click', function() {
-        window.location.href = '/auth/logout';
-      });
-      
-      // Проверяем URL для параметра loggedIn
-      const urlParams = new URLSearchParams(window.location.search);
-      if (urlParams.get('loggedIn') === 'true') {
-        // Обновляем интерфейс после успешного входа
-        checkAuthStatus();
-        // Очищаем URL
-        window.history.replaceState({}, document.title, window.location.pathname);
-      }
-    }
-    
     // Запускаем игру при клике на play-image
     function setupPlayButton() {
       $('#play-image').on('click', function() {
         window.location.href = '/game';
       });
-      
+
       // Обработчик для изображения лидерборда
       $('#leaderboard-image').on('click', function() {
         window.location.href = '/leaderboard';
       });
     }
-    
-    // Создаем фон
-    function createSpaceBackground() {
-      const spaceBackground = $("#space-background");
-      if (spaceBackground.length === 0) {
-        $("<div id='space-background'></div>").css({
-          'position': 'fixed',
-          'top': 0,
-          'left': 0,
-          'width': '100%',
-          'height': '100%',
-          'z-index': -1,
-          'overflow': 'hidden',
-          'background-image': 'url("images/backgroundseismic.png")',
-          'background-size': '100% 100%',
-          'background-position': 'center'
-        }).prependTo("body");
-      }
-    }
-    
+
     $(document).ready(function() {
-      createSpaceBackground();
+      createSpaceBackground('images/backgroundseismic.png');
       setupAuthButtons();
       setupPlayButton();
       checkAuthStatus();

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -159,6 +159,7 @@
   <a href="./" class="back-button">Back to Game</a>
   
   <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <script src="js/common.js"></script>
   <script src="js/leaderboard.js"></script>
 </body>
 </html>

--- a/public/js/common.js
+++ b/public/js/common.js
@@ -1,0 +1,65 @@
+// Общие функции авторизации и интерфейса
+
+async function checkAuthStatus() {
+  try {
+    const response = await fetch('/api/auth-status');
+    const data = await response.json();
+
+    if (data.authenticated) {
+      $('#not-logged').hide();
+      $('#logged-in').show();
+      $('#username').text(data.user.username);
+
+      if (data.user.avatar) {
+        const avatarUrl = `https://cdn.discordapp.com/avatars/${data.user.id}/${data.user.avatar}.png`;
+        $('#user-avatar').attr('src', avatarUrl);
+      } else {
+        $('#user-avatar').attr('src', 'https://cdn.discordapp.com/embed/avatars/0.png');
+      }
+
+      return true;
+    } else {
+      $('#not-logged').show();
+      $('#logged-in').hide();
+      return false;
+    }
+  } catch (error) {
+    console.error('Ошибка при проверке статуса авторизации:', error);
+    return false;
+  }
+}
+
+function setupAuthButtons() {
+  $('#discord-login').on('click', function() {
+    window.location.href = '/auth/discord';
+  });
+
+  $('#logout').on('click', function() {
+    window.location.href = '/auth/logout';
+  });
+
+  const urlParams = new URLSearchParams(window.location.search);
+  if (urlParams.get('loggedIn') === 'true') {
+    checkAuthStatus();
+    window.history.replaceState({}, document.title, window.location.pathname);
+  }
+}
+
+function createSpaceBackground(imagePath) {
+  const spaceBackground = $('#space-background');
+  if (spaceBackground.length === 0) {
+    $('<div id="space-background"></div>').prependTo('body');
+  }
+  $('#space-background').css({
+    position: 'fixed',
+    top: 0,
+    left: 0,
+    width: '100%',
+    height: '100%',
+    'z-index': -1,
+    overflow: 'hidden',
+    'background-image': `url("${imagePath}")`,
+    'background-size': '100% 100%',
+    'background-position': 'center'
+  });
+}

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -535,61 +535,6 @@ function getRandom(min, max) {
   return Math.random() * (max - min) + min;
 }
 
-// Функции для работы с Discord авторизацией
-async function checkAuthStatus() {
-  try {
-    const response = await fetch('/api/auth-status');
-    const data = await response.json();
-    
-    if (data.authenticated) {
-      // Пользователь авторизован
-      $('#not-logged').hide();
-      $('#logged-in').show();
-      $('#username').text(data.user.username);
-      
-      // Устанавливаем аватар пользователя
-      if (data.user.avatar) {
-        const avatarUrl = `https://cdn.discordapp.com/avatars/${data.user.id}/${data.user.avatar}.png`;
-        $('#user-avatar').attr('src', avatarUrl);
-      } else {
-        // Дефолтный аватар если у пользователя нет аватара
-        $('#user-avatar').attr('src', 'https://cdn.discordapp.com/embed/avatars/0.png');
-      }
-      
-      return true;
-    } else {
-      // Пользователь не авторизован
-      $('#not-logged').show();
-      $('#logged-in').hide();
-      return false;
-    }
-  } catch (error) {
-    console.error('Ошибка при проверке статуса авторизации:', error);
-    return false;
-  }
-}
-
-// Обработчики событий для кнопок авторизации
-function setupAuthButtons() {
-  // Кнопка входа через Discord
-  $('#discord-login').on('click', function() {
-    window.location.href = '/auth/discord';
-  });
-  
-  // Кнопка выхода
-  $('#logout').on('click', function() {
-    window.location.href = '/auth/logout';
-  });
-  
-  // Проверяем URL для параметра loggedIn
-  const urlParams = new URLSearchParams(window.location.search);
-  if (urlParams.get('loggedIn') === 'true') {
-    // Обновляем интерфейс после успешного входа
-    checkAuthStatus();
-    // Очищаем URL
-    window.history.replaceState({}, document.title, window.location.pathname);
-  }
-}
 
 // Функция для сохранения счета пользователя
 async function saveScore(score) {
@@ -608,23 +553,6 @@ async function saveScore(score) {
   }
 }
 
-function createSpaceBackground() {
-  const spaceBackground = $("#space-background");
-  if (spaceBackground.length) {
-    spaceBackground.css({
-      'position': 'fixed',
-      'top': 0,
-      'left': 0,
-      'width': '100%',
-      'height': '100%',
-      'z-index': -1,
-      'overflow': 'hidden',
-      'background-image': 'url("../images/backgroundseismic.png")',
-      'background-size': '100% 100%',
-      'background-position': 'center'
-    });
-  }
-}
 
 $(async function () {
   // Инициализация авторизации
@@ -632,7 +560,7 @@ $(async function () {
   await checkAuthStatus();
   
   // Создаем фон
-  createSpaceBackground();
+  createSpaceBackground("images/backgroundseismic.png");
   
   // Обработчик для кнопки запуска игры (изображение)
   $("#intro-image").on("click", async function() {

--- a/public/js/leaderboard.js
+++ b/public/js/leaderboard.js
@@ -68,82 +68,6 @@ async function loadLeaderboard() {
   }
 }
 
-// Функции для работы с Discord авторизацией
-async function checkAuthStatus() {
-  try {
-    const response = await fetch('/api/auth-status');
-    const data = await response.json();
-    
-    if (data.authenticated) {
-      // Пользователь авторизован
-      $('#not-logged').hide();
-      $('#logged-in').show();
-      $('#username').text(data.user.username);
-      
-      // Устанавливаем аватар пользователя
-      if (data.user.avatar) {
-        const avatarUrl = `https://cdn.discordapp.com/avatars/${data.user.id}/${data.user.avatar}.png`;
-        $('#user-avatar').attr('src', avatarUrl);
-      } else {
-        // Дефолтный аватар если у пользователя нет аватара
-        $('#user-avatar').attr('src', 'https://cdn.discordapp.com/embed/avatars/0.png');
-      }
-      
-      return true;
-    } else {
-      // Пользователь не авторизован
-      $('#not-logged').show();
-      $('#logged-in').hide();
-      return false;
-    }
-  } catch (error) {
-    console.error('Error checking auth status:', error);
-    return false;
-  }
-}
-
-function setupAuthButtons() {
-  // Кнопка входа через Discord
-  $('#discord-login').on('click', function() {
-    window.location.href = '/auth/discord';
-  });
-  
-  // Кнопка выхода
-  $('#logout').on('click', function() {
-    window.location.href = '/auth/logout';
-  });
-  
-  // Проверяем URL для параметра loggedIn
-  const urlParams = new URLSearchParams(window.location.search);
-  if (urlParams.get('loggedIn') === 'true') {
-    // Обновляем интерфейс после успешного входа
-    checkAuthStatus();
-    // Очищаем URL
-    window.history.replaceState({}, document.title, window.location.pathname);
-  }
-}
-
-// Создаем фон (как в основной игре)
-function createSpaceBackground() {
-  console.log('Создаем фон...');
-  const spaceBackground = $("#space-background");
-  if (spaceBackground.length === 0) {
-    console.log('Создаем новый элемент фона...');
-    $("<div id='space-background'></div>").css({
-      'position': 'fixed',
-      'top': 0,
-      'left': 0,
-      'width': '100%',
-      'height': '100%',
-      'z-index': -1,
-      'overflow': 'hidden',
-      'background-image': 'url("vulkan.png")',
-      'background-size': '100% 100%',
-      'background-position': 'center'
-    }).prependTo("body");
-    console.log('Фон создан.');
-  }
-}
 
 // Инициализация при загрузке страницы
 $(document).ready(function() {
@@ -151,7 +75,7 @@ $(document).ready(function() {
   console.log('jQuery версия:', $.fn.jquery);
   
   try {
-    createSpaceBackground();
+    createSpaceBackground("images/vulkan.png");
     console.log('Настраиваем кнопки авторизации...');
     setupAuthButtons();
     console.log('Проверяем статус авторизации...');


### PR DESCRIPTION
## Summary
- centralize common auth functions and background helper in `public/js/common.js`
- import shared script on all pages and remove duplicate code
- call helpers from `game.js` and `leaderboard.js`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683fe79b45408331beaab5ea11d2e32e