### PR TITLE
Add duration tracking to scores

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Seismic Quiz Game
 
-An interactive quiz game with Discord authentication built with Node.js and Express. Players can log in using their Discord account, answer quiz questions and track high scores on a leaderboard stored in SQLite.
+An interactive quiz game with Discord authentication built with Node.js and Express. Players can log in using their Discord account, answer quiz questions and track high scores on a leaderboard stored in SQLite. Each saved score now also records how long it took to finish the quiz and this time appears on the leaderboard.
 
 ## Requirements
 

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -144,6 +144,7 @@
           <th>Rank</th>
           <th>Player</th>
           <th>Score</th>
+          <th>Time</th>
           <th>Date</th>
         </tr>
       </thead>

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -283,6 +283,7 @@ class Game {
     this.quiz = quiz;
     this.timeLeft = 20;
     this.canAnswer = true;
+    this.startTime = null;
 
     // Load background and planets during intro screen
     this.createSpaceBackground();
@@ -298,6 +299,7 @@ class Game {
 
   startGame() {
     // Initialize player and start displaying elements after intro
+    this.startTime = Date.now();
     this.player = new Player({
       controls: this.controls,
       parentContainer: this.container,
@@ -515,17 +517,19 @@ class Game {
       userInfo = `<p class="user-result">Player: ${usernameElement.text()}</p>`;
     }
     
+    const duration = Math.floor((Date.now() - this.startTime) / 1000);
     const gameOverEl = $(
       `<div class='game-over'>
          ${userInfo}
          <p>Final Score: ${this.quiz.score}</p>
+         <p>Time: ${duration}s</p>
        </div>`
     );
     
     this.container.append(gameOverEl);
     
     // Сохраняем счет если пользователь авторизован
-    saveScore(this.quiz.score);
+    saveScore(this.quiz.score, duration);
   }
 }
 
@@ -535,14 +539,14 @@ function getRandom(min, max) {
 
 
 // Функция для сохранения счета пользователя
-async function saveScore(score) {
+async function saveScore(score, duration) {
   try {
     const response = await fetch('/api/save-score', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'
       },
-      body: JSON.stringify({ score })
+      body: JSON.stringify({ score, duration })
     });
     const data = await response.json();
     console.log('Счет сохранен:', data);

--- a/public/js/leaderboard.js
+++ b/public/js/leaderboard.js
@@ -4,7 +4,7 @@ async function loadLeaderboard() {
     console.log('Запрашиваем данные лидерборда...');
     
     // Очищаем таблицу и показываем сообщение о загрузке
-    $('#leaderboard-body').html('<tr><td colspan="4">Loading leaderboard data...</td></tr>');
+    $('#leaderboard-body').html('<tr><td colspan="5">Loading leaderboard data...</td></tr>');
     
     const response = await fetch('/api/leaderboard');
     console.log('Ответ получен:', response);
@@ -18,7 +18,7 @@ async function loadLeaderboard() {
     
     if (!Array.isArray(data)) {
       console.error('Неверный формат данных:', data);
-      $('#leaderboard-body').html('<tr><td colspan="4">Error: Invalid data format</td></tr>');
+      $('#leaderboard-body').html('<tr><td colspan="5">Error: Invalid data format</td></tr>');
       return;
     }
     
@@ -55,6 +55,9 @@ async function loadLeaderboard() {
           .text(entry.score || 0)
           .appendTo(tr);
         $('<td>')
+          .text((entry.duration || 0) + 's')
+          .appendTo(tr);
+        $('<td>')
           .text(formattedDate)
           .appendTo(tr);
         tbody.append(tr);
@@ -62,7 +65,7 @@ async function loadLeaderboard() {
     }
   } catch (error) {
     console.error('Error loading leaderboard:', error);
-    $('#leaderboard-body').html('<tr><td colspan="4">Error loading leaderboard: ' + error.message + '</td></tr>');
+    $('#leaderboard-body').html('<tr><td colspan="5">Error loading leaderboard: ' + error.message + '</td></tr>');
     $('#global-leaderboard').show();
     $('#no-scores').hide();
   }

--- a/src/controllers/gameController.js
+++ b/src/controllers/gameController.js
@@ -80,12 +80,12 @@ exports.saveScore = (req, res) => {
     return res.status(401).json({ error: 'You must be logged in to save scores' });
   }
   
-  const { score } = req.body;
+  const { score, duration } = req.body;
   const userId = req.user.id;
   const username = req.user.username;
-  
+
   // Сохраняем счет в базе данных
-  db.saveScore(userId, username, score)
+  db.saveScore(userId, username, score, duration)
     .then(id => res.json({ success: true, id }))
     .catch(err => {
       console.error('Ошибка сохранения счета:', err);

--- a/src/models/db.js
+++ b/src/models/db.js
@@ -29,6 +29,7 @@ function initDatabase() {
                 userId TEXT NOT NULL,
                 username TEXT NOT NULL,
                 score INTEGER NOT NULL,
+                duration INTEGER,
                 timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
             )
         `);
@@ -57,16 +58,16 @@ function insertTestData() {
     console.log('Добавляем тестовые данные в лидерборд...');
     
     const testData = [
-        { userId: '12345', username: 'lumin.eth', score: 70 }
+        { userId: '12345', username: 'lumin.eth', score: 70, duration: 30 }
     ];
-    
+
     const stmt = db.prepare(`
-        INSERT INTO scores (userId, username, score)
-        VALUES (?, ?, ?)
+        INSERT INTO scores (userId, username, score, duration)
+        VALUES (?, ?, ?, ?)
     `);
     
     testData.forEach(data => {
-        stmt.run(data.userId, data.username, data.score, (err) => {
+        stmt.run(data.userId, data.username, data.score, data.duration, (err) => {
             if (err) {
                 console.error('Ошибка при добавлении тестовых данных:', err);
             }
@@ -89,7 +90,7 @@ function getLeaderboard(limit = 10) {
                 FROM scores
                 GROUP BY username
             )
-            SELECT s.username, s.score, s.timestamp
+            SELECT s.username, s.score, s.duration, s.timestamp
             FROM scores s
             JOIN MaxScores m ON s.username = m.username AND s.score = m.maxScore
             ORDER BY s.score DESC
@@ -112,11 +113,11 @@ function getLeaderboard(limit = 10) {
  * @param {number} score - счет
  * @returns {Promise<number>} - промис с ID новой записи
  */
-function saveScore(userId, username, score) {
+function saveScore(userId, username, score, duration) {
     return new Promise((resolve, reject) => {
         db.run(
-            `INSERT INTO scores (userId, username, score) VALUES (?, ?, ?)`,
-            [userId, username, score],
+            `INSERT INTO scores (userId, username, score, duration) VALUES (?, ?, ?, ?)`,
+            [userId, username, score, duration],
             function (err) {
                 if (err) {
                     console.error('Ошибка при сохранении счета:', err);


### PR DESCRIPTION
## Summary
- record time spent in `Game` class and send to server
- display duration at game over and save with score
- store duration in SQLite scores table
- show "Time" column on leaderboard
- document new duration field in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683ff007afc08331a1fc3fb35e745342